### PR TITLE
feat: HIVE-876 Add a vendor creation date column to individual model

### DIFF
--- a/mci_database/db/migrations/versions/08dad05889a9_.py
+++ b/mci_database/db/migrations/versions/08dad05889a9_.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 08dad05889a9
+Revises: 05c4d470cd9c
+Create Date: 2020-07-22 13:07:06.139549
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '08dad05889a9'
+down_revision = '05c4d470cd9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('individual', sa.Column(
+        'vendor_creation_date', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('individual', 'vendor_creation_date')

--- a/mci_database/db/models/models.py
+++ b/mci_database/db/models/models.py
@@ -160,6 +160,7 @@ class Individual(db.Model):
     ssn = db.Column(db.String(20))
     registration_date = db.Column(
         db.DateTime, server_default=db.func.now(), nullable=False)
+    vendor_creation_date = db.Column(db.DateTime)
     first_name = db.Column(db.String(100))
     suffix = db.Column(db.String(10))
     middle_name = db.Column(db.String(100))


### PR DESCRIPTION
# Description

Add a vendor creation date column to the individual model to allow users the ability to track a system creation date on a target system, which may be different from the MCI creation date.

# Checklists

### Basic

- [ ] Did you write tests for the code in this PR?
- [ ] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

### Frontend

- [ ] HTTP links should embed text that clearly explains what information your readers will find when they click on a hyperlink. [Read more about HTML accessibility](https://accessibility.umn.edu/core-skills/hyperlinks).

# Notes for the Reviewer

A precise explanation of what the PR reviewer needs to evaluate. This might be:

* a low-level code review of certain functions
* a high-level assessment of strategy or architecture
* a confirmation that the code behaves as expected on another machine